### PR TITLE
Integrate StreamManager with run_sweep()

### DIFF
--- a/cirq-core/cirq/ops/parity_gates.py
+++ b/cirq-core/cirq/ops/parity_gates.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     import cirq
 
 
+@value.value_equality
 class XXPowGate(gate_features.InterchangeableQubitsGate, eigen_gate.EigenGate):
     r"""The X-parity gate, possibly raised to a power.
 
@@ -133,6 +134,7 @@ class XXPowGate(gate_features.InterchangeableQubitsGate, eigen_gate.EigenGate):
         )
 
 
+@value.value_equality
 class YYPowGate(gate_features.InterchangeableQubitsGate, eigen_gate.EigenGate):
     r"""The Y-parity gate, possibly raised to a power.
 
@@ -237,6 +239,7 @@ class YYPowGate(gate_features.InterchangeableQubitsGate, eigen_gate.EigenGate):
         )
 
 
+@value.value_equality
 class ZZPowGate(gate_features.InterchangeableQubitsGate, eigen_gate.EigenGate):
     r"""The Z-parity gate, possibly raised to a power.
 

--- a/cirq-core/cirq/ops/parity_gates_test.py
+++ b/cirq-core/cirq/ops/parity_gates_test.py
@@ -257,8 +257,24 @@ def test_trace_distance():
 
 def test_ms_arguments():
     eq_tester = cirq.testing.EqualsTester()
-    eq_tester.add_equality_group(cirq.ms(np.pi / 2), cirq.ops.MSGate(rads=np.pi / 2))
-    eq_tester.add_equality_group(cirq.XXPowGate(global_shift=-0.5))
+    eq_tester.add_equality_group(
+        cirq.ms(np.pi / 2), cirq.ops.MSGate(rads=np.pi / 2), cirq.XXPowGate(global_shift=-0.5)
+    )
+    eq_tester.add_equality_group(
+        cirq.ms(np.pi / 4), cirq.XXPowGate(exponent=0.5, global_shift=-0.5)
+    )
+    eq_tester.add_equality_group(cirq.XX)
+    eq_tester.add_equality_group(cirq.XX**0.5)
+
+
+def test_ms_equal_up_to_global_phase():
+    assert cirq.equal_up_to_global_phase(cirq.ms(np.pi / 2), cirq.XX)
+    assert cirq.equal_up_to_global_phase(cirq.ms(np.pi / 4), cirq.XX**0.5)
+    assert not cirq.equal_up_to_global_phase(cirq.ms(np.pi / 4), cirq.XX)
+
+    assert cirq.ms(np.pi / 2) in cirq.GateFamily(cirq.XX)
+    assert cirq.ms(np.pi / 4) in cirq.GateFamily(cirq.XX**0.5)
+    assert cirq.ms(np.pi / 4) not in cirq.GateFamily(cirq.XX)
 
 
 def test_ms_str():

--- a/cirq-google/cirq_google/engine/engine.py
+++ b/cirq-google/cirq_google/engine/engine.py
@@ -340,7 +340,6 @@ class Engine(abstract_engine.AbstractEngine):
 
     run_sweep = duet.sync(run_sweep_async)
 
-    # TODO update
     async def run_batch_async(
         self,
         programs: Sequence[cirq.AbstractCircuit],
@@ -586,6 +585,7 @@ class Engine(abstract_engine.AbstractEngine):
 
     create_batch_program = duet.sync(create_batch_program_async)
 
+    # TODO(#5996) Migrate to stream client
     async def create_calibration_program_async(
         self,
         layers: List['cirq_google.CalibrationLayer'],

--- a/cirq-google/cirq_google/engine/engine.py
+++ b/cirq-google/cirq_google/engine/engine.py
@@ -320,11 +320,11 @@ class Engine(abstract_engine.AbstractEngine):
 
         stream_job_response_future = self.context.client.run_job_over_stream(
             project_id=self.project_id,
-            program_id=program_id,
+            program_id=str(program_id),
             program_description=program_description,
             program_labels=program_labels,
             code=self.context._serialize_program(program),
-            job_id=job_id,
+            job_id=str(job_id),
             processor_ids=processor_ids,
             run_context=run_context,
             job_description=job_description,
@@ -332,8 +332,8 @@ class Engine(abstract_engine.AbstractEngine):
         )
         return engine_job.EngineJob(
             self.project_id,
-            program_id,
-            job_id,
+            str(program_id),
+            str(job_id),
             self.context,
             stream_job_response_future=stream_job_response_future,
         )

--- a/cirq-google/cirq_google/engine/engine.py
+++ b/cirq-google/cirq_google/engine/engine.py
@@ -340,6 +340,7 @@ class Engine(abstract_engine.AbstractEngine):
 
     run_sweep = duet.sync(run_sweep_async)
 
+    # TODO(#5996) Migrate to stream client
     async def run_batch_async(
         self,
         programs: Sequence[cirq.AbstractCircuit],
@@ -420,7 +421,7 @@ class Engine(abstract_engine.AbstractEngine):
 
     run_batch = duet.sync(run_batch_async)
 
-    # TODO update
+    # TODO(#5996) Migrate to stream client
     async def run_calibration_async(
         self,
         layers: List['cirq_google.CalibrationLayer'],
@@ -585,7 +586,6 @@ class Engine(abstract_engine.AbstractEngine):
 
     create_batch_program = duet.sync(create_batch_program_async)
 
-    # TODO(#5996) Migrate to stream client
     async def create_calibration_program_async(
         self,
         layers: List['cirq_google.CalibrationLayer'],

--- a/cirq-google/cirq_google/engine/engine_client.py
+++ b/cirq-google/cirq_google/engine/engine_client.py
@@ -38,7 +38,7 @@ from google.protobuf.timestamp_pb2 import Timestamp
 from cirq._compat import cached_property
 from cirq_google.cloud import quantum
 from cirq_google.engine.asyncio_executor import AsyncioExecutor
-from cirq_google.engine.stream_manager import StreamManager
+from cirq_google.engine import stream_manager
 
 _M = TypeVar('_M', bound=proto.Message)
 _R = TypeVar('_R')
@@ -107,8 +107,8 @@ class EngineClient:
         return self._executor.submit(make_client).result()
 
     @cached_property
-    def _stream_manager(self) -> StreamManager:
-        return StreamManager(self.grpc_client)
+    def _stream_manager(self) -> stream_manager.StreamManager:
+        return stream_manager.StreamManager(self.grpc_client)
 
     async def _send_request_async(self, func: Callable[[_M], Awaitable[_R]], request: _M) -> _R:
         """Sends a request by invoking an asyncio callable."""
@@ -721,6 +721,19 @@ class EngineClient:
         Sends the request over the Quantum Engine QuantumRunStream bidirectional stream, and returns
         a future for the stream response. The future will be completed with a `QuantumResult` if
         the job is successful; otherwise, it will be completed with a QuantumJob.
+
+        Args:
+            project_id: A project_id of the parent Google Cloud Project.
+            program_id: Unique ID of the program within the parent project.
+            code: Properly serialized program code.
+            job_id: Unique ID of the job within the parent program.
+            run_context: Properly serialized run context.
+            processor_ids: List of processor id for running the program.
+            program_description: An optional description to set on the program.
+            program_labels: Optional set of labels to set on the program.
+            priority: Optional priority to run at, 0-1000.
+            job_description: Optional description to set on the job.
+            job_labels: Optional set of labels to set on the job.
         """
         # Check program to run and program parameters.
         if priority and not 0 <= priority < 1000:

--- a/cirq-google/cirq_google/engine/engine_client.py
+++ b/cirq-google/cirq_google/engine/engine_client.py
@@ -734,6 +734,12 @@ class EngineClient:
             priority: Optional priority to run at, 0-1000.
             job_description: Optional description to set on the job.
             job_labels: Optional set of labels to set on the job.
+
+        Returns:
+            A future for the job result, or the job if the job has failed.
+
+        Raises:
+            ValueError: If the priority is not between 0 and 1000.
         """
         # Check program to run and program parameters.
         if priority and not 0 <= priority < 1000:

--- a/cirq-google/cirq_google/engine/engine_client.py
+++ b/cirq-google/cirq_google/engine/engine_client.py
@@ -38,6 +38,7 @@ from google.protobuf.timestamp_pb2 import Timestamp
 from cirq._compat import cached_property
 from cirq_google.cloud import quantum
 from cirq_google.engine.asyncio_executor import AsyncioExecutor
+from cirq_google.engine.stream_manager import StreamManager
 
 _M = TypeVar('_M', bound=proto.Message)
 _R = TypeVar('_R')
@@ -104,6 +105,10 @@ class EngineClient:
                 return quantum.QuantumEngineServiceAsyncClient(**self._service_args)
 
         return self._executor.submit(make_client).result()
+
+    @cached_property
+    def _stream_manager(self) -> StreamManager:
+        return StreamManager(self.grpc_client)
 
     async def _send_request_async(self, func: Callable[[_M], Awaitable[_R]], request: _M) -> _R:
         """Sends a request by invoking an asyncio callable."""
@@ -696,6 +701,60 @@ class EngineClient:
         return await self._send_request_async(self.grpc_client.get_quantum_result, request)
 
     get_job_results = duet.sync(get_job_results_async)
+
+    def run_job_over_stream(
+        self,
+        project_id: str,
+        program_id: str,
+        code: any_pb2.Any,
+        job_id: str,
+        processor_ids: Sequence[str],
+        run_context: any_pb2.Any,
+        program_description: Optional[str] = None,
+        program_labels: Optional[Dict[str, str]] = None,
+        priority: Optional[int] = None,
+        job_description: Optional[str] = None,
+        job_labels: Optional[Dict[str, str]] = None,
+    ) -> duet.AwaitableFuture[Union[quantum.QuantumResult, quantum.QuantumJob]]:
+        """Runs a job with the given program and job information over a stream.
+
+        Sends the request over the Quantum Engine QuantumRunStream bidirectional stream, and returns
+        a future for the stream response. The future will be completed with a `QuantumResult` if
+        the job is successful; otherwise, it will be completed with a QuantumJob.
+        """
+        # Check program to run and program parameters.
+        if priority and not 0 <= priority < 1000:
+            raise ValueError('priority must be between 0 and 1000')
+
+        project_name = _project_name(project_id)
+
+        program_name = _program_name_from_ids(project_id, program_id)
+        program = quantum.QuantumProgram(name=program_name, code=code)
+        if program_description:
+            program.description = program_description
+        if program_labels:
+            program.labels.update(program_labels)
+
+        job = quantum.QuantumJob(
+            name=_job_name_from_ids(project_id, program_id, job_id),
+            scheduling_config=quantum.SchedulingConfig(
+                processor_selector=quantum.SchedulingConfig.ProcessorSelector(
+                    processor_names=[
+                        _processor_name_from_ids(project_id, processor_id)
+                        for processor_id in processor_ids
+                    ]
+                )
+            ),
+            run_context=run_context,
+        )
+        if priority:
+            job.scheduling_config.priority = priority
+        if job_description:
+            job.description = job_description
+        if job_labels:
+            job.labels.update(job_labels)
+
+        return self._stream_manager.submit(project_name, program, job)
 
     async def list_processors_async(self, project_id: str) -> List[quantum.QuantumProcessor]:
         """Returns a list of Processors that the user has visibility to in the

--- a/cirq-google/cirq_google/engine/engine_job.py
+++ b/cirq-google/cirq_google/engine/engine_job.py
@@ -286,7 +286,8 @@ class EngineJob(abstract_job.AbstractJob):
         import cirq_google.engine.engine as engine_base
 
         if self._results is None:
-            result = await self._await_result_async()
+            result_response = await self._await_result_async()
+            result = result_response.result
             result_type = result.type_url[len(engine_base.TYPE_PREFIX) :]
             if (
                 result_type == 'cirq.google.api.v1.Result'
@@ -330,7 +331,7 @@ class EngineJob(abstract_job.AbstractJob):
         response = await self.context.client.get_job_results_async(
             self.project_id, self.program_id, self.job_id
         )
-        return response.result
+        return response
 
     async def calibration_results_async(self) -> Sequence[CalibrationResult]:
         """Returns the results of a run_calibration() call.
@@ -341,7 +342,8 @@ class EngineJob(abstract_job.AbstractJob):
         import cirq_google.engine.engine as engine_base
 
         if self._calibration_results is None:
-            result = await self._await_result_async()
+            result_response = await self._await_result_async()
+            result = result_response.result
             result_type = result.type_url[len(engine_base.TYPE_PREFIX) :]
             if result_type != 'cirq.google.api.v2.FocusedCalibrationResult':
                 raise ValueError(f'Did not find calibration results, instead found: {result_type}')

--- a/cirq-google/cirq_google/engine/engine_processor_test.py
+++ b/cirq-google/cirq_google/engine/engine_processor_test.py
@@ -15,6 +15,7 @@
 from unittest import mock
 import datetime
 
+import duet
 import pytest
 import freezegun
 import numpy as np
@@ -799,22 +800,13 @@ def test_list_reservations_time_filter_behavior(list_reservations):
 
 @mock.patch('cirq_google.engine.engine_client.EngineClient', autospec=True)
 def test_run_sweep_params(client):
-    client().create_program_async.return_value = (
-        'prog',
-        quantum.QuantumProgram(name='projects/proj/programs/prog'),
-    )
-    client().create_job_async.return_value = (
-        'job-id',
-        quantum.QuantumJob(
-            name='projects/proj/programs/prog/jobs/job-id', execution_status={'state': 'READY'}
-        ),
-    )
     client().get_job_async.return_value = quantum.QuantumJob(
         execution_status={'state': 'SUCCESS'}, update_time=_to_timestamp('2019-07-09T23:39:59Z')
     )
-    client().get_job_results_async.return_value = quantum.QuantumResult(
-        result=util.pack_any(_RESULTS_V2)
-    )
+    expected_result = quantum.QuantumResult(result=util.pack_any(_RESULTS_V2))
+    stream_future = duet.AwaitableFuture()
+    stream_future.try_set_result(expected_result)
+    client().run_job_over_stream.return_value = stream_future
 
     processor = cg.EngineProcessor('a', 'p', EngineContext())
     job = processor.run_sweep(
@@ -831,18 +823,15 @@ def test_run_sweep_params(client):
         assert result.job_finished_time is not None
     assert results == cirq.read_json(json_text=cirq.to_json(results))
 
-    client().create_program_async.assert_called_once()
-    client().create_job_async.assert_called_once()
+    client().run_job_over_stream.assert_called_once()
 
     run_context = v2.run_context_pb2.RunContext()
-    client().create_job_async.call_args[1]['run_context'].Unpack(run_context)
+    client().run_job_over_stream.call_args[1]['run_context'].Unpack(run_context)
     sweeps = run_context.parameter_sweeps
     assert len(sweeps) == 2
     for i, v in enumerate([1.0, 2.0]):
         assert sweeps[i].repetitions == 1
         assert sweeps[i].sweep.sweep_function.sweeps[0].single_sweep.points.points == [v]
-    client().get_job_async.assert_called_once()
-    client().get_job_results_async.assert_called_once()
 
 
 @mock.patch('cirq_google.engine.engine_client.EngineClient', autospec=True)
@@ -943,22 +932,14 @@ def test_run_calibration(client):
 
 @mock.patch('cirq_google.engine.engine_client.EngineClient', autospec=True)
 def test_sampler(client):
-    client().create_program_async.return_value = (
-        'prog',
-        quantum.QuantumProgram(name='projects/proj/programs/prog'),
-    )
-    client().create_job_async.return_value = (
-        'job-id',
-        quantum.QuantumJob(
-            name='projects/proj/programs/prog/jobs/job-id', execution_status={'state': 'READY'}
-        ),
-    )
     client().get_job_async.return_value = quantum.QuantumJob(
         execution_status={'state': 'SUCCESS'}, update_time=_to_timestamp('2019-07-09T23:39:59Z')
     )
-    client().get_job_results_async.return_value = quantum.QuantumResult(
-        result=util.pack_any(_RESULTS_V2)
-    )
+    expected_result = quantum.QuantumResult(result=util.pack_any(_RESULTS_V2))
+    stream_future = duet.AwaitableFuture()
+    stream_future.try_set_result(expected_result)
+    client().run_job_over_stream.return_value = stream_future
+
     processor = cg.EngineProcessor('proj', 'mysim', EngineContext())
     sampler = processor.get_sampler()
     results = sampler.run_sweep(
@@ -969,7 +950,7 @@ def test_sampler(client):
         assert results[i].repetitions == 1
         assert results[i].params.param_dict == {'a': v}
         assert results[i].measurements == {'q': np.array([[0]], dtype='uint8')}
-    assert client().create_program_async.call_args[0][0] == 'proj'
+    assert client().run_job_over_stream.call_args[1]['project_id'] == 'proj'
 
 
 def test_str():

--- a/cirq-google/cirq_google/engine/engine_test.py
+++ b/cirq-google/cirq_google/engine/engine_test.py
@@ -19,6 +19,7 @@ import time
 import numpy as np
 import pytest
 
+import duet
 from google.protobuf import any_pb2, timestamp_pb2
 from google.protobuf.text_format import Merge
 
@@ -348,6 +349,9 @@ def setup_run_circuit_with_result_(client, result):
         execution_status={'state': 'SUCCESS'}, update_time=_DT
     )
     client().get_job_results_async.return_value = quantum.QuantumResult(result=result)
+    stream_future = duet.AwaitableFuture()
+    stream_future.try_set_result(quantum.QuantumResult(result=result))
+    client().run_job_over_stream.return_value = stream_future
 
 
 @mock.patch('cirq_google.engine.engine_client.EngineClient', autospec=True)
@@ -363,10 +367,10 @@ def test_run_circuit(client):
     assert result.params.param_dict == {'a': 1}
     assert result.measurements == {'q': np.array([[0]], dtype='uint8')}
     client.assert_called_with(service_args={'client_info': 1}, verbose=None)
-    client().create_program_async.assert_called_once()
-    client().create_job_async.assert_called_once_with(
+    client().run_job_over_stream.assert_called_once_with(
         project_id='proj',
         program_id='prog',
+        code=mock.ANY,
         job_id='job-id',
         processor_ids=['mysim'],
         run_context=util.pack_any(
@@ -374,11 +378,11 @@ def test_run_circuit(client):
                 parameter_sweeps=[v2.run_context_pb2.ParameterSweep(repetitions=1)]
             )
         ),
-        description=None,
-        labels=None,
+        program_description=None,
+        program_labels=None,
+        job_description=None,
+        job_labels=None,
     )
-    client().get_job_async.assert_called_once_with('proj', 'prog', 'job-id', False)
-    client().get_job_results_async.assert_called_once_with('proj', 'prog', 'job-id')
 
 
 def test_no_gate_set():
@@ -394,17 +398,7 @@ def test_unsupported_program_type():
 
 @mock.patch('cirq_google.engine.engine_client.EngineClient', autospec=True)
 def test_run_circuit_failed(client):
-    client().create_program_async.return_value = (
-        'prog',
-        quantum.QuantumProgram(name='projects/proj/programs/prog'),
-    )
-    client().create_job_async.return_value = (
-        'job-id',
-        quantum.QuantumJob(
-            name='projects/proj/programs/prog/jobs/job-id', execution_status={'state': 'READY'}
-        ),
-    )
-    client().get_job_async.return_value = quantum.QuantumJob(
+    failed_job = quantum.QuantumJob(
         name='projects/proj/programs/prog/jobs/job-id',
         execution_status={
             'state': 'FAILURE',
@@ -412,6 +406,9 @@ def test_run_circuit_failed(client):
             'failure': {'error_code': 'SYSTEM_ERROR', 'error_message': 'Not good'},
         },
     )
+    stream_future = duet.AwaitableFuture()
+    stream_future.try_set_result(failed_job)
+    client().run_job_over_stream.return_value = stream_future
 
     engine = cg.Engine(project_id='proj')
     with pytest.raises(
@@ -424,23 +421,16 @@ def test_run_circuit_failed(client):
 
 @mock.patch('cirq_google.engine.engine_client.EngineClient', autospec=True)
 def test_run_circuit_failed_missing_processor_name(client):
-    client().create_program_async.return_value = (
-        'prog',
-        quantum.QuantumProgram(name='projects/proj/programs/prog'),
-    )
-    client().create_job_async.return_value = (
-        'job-id',
-        quantum.QuantumJob(
-            name='projects/proj/programs/prog/jobs/job-id', execution_status={'state': 'READY'}
-        ),
-    )
-    client().get_job_async.return_value = quantum.QuantumJob(
+    failed_job = quantum.QuantumJob(
         name='projects/proj/programs/prog/jobs/job-id',
         execution_status={
             'state': 'FAILURE',
             'failure': {'error_code': 'SYSTEM_ERROR', 'error_message': 'Not good'},
         },
     )
+    stream_future = duet.AwaitableFuture()
+    stream_future.try_set_result(failed_job)
+    client().run_job_over_stream.return_value = stream_future
 
     engine = cg.Engine(project_id='proj')
     with pytest.raises(
@@ -453,45 +443,17 @@ def test_run_circuit_failed_missing_processor_name(client):
 
 @mock.patch('cirq_google.engine.engine_client.EngineClient', autospec=True)
 def test_run_circuit_cancelled(client):
-    client().create_program_async.return_value = (
-        'prog',
-        quantum.QuantumProgram(name='projects/proj/programs/prog'),
-    )
-    client().create_job_async.return_value = (
-        'job-id',
-        quantum.QuantumJob(
-            name='projects/proj/programs/prog/jobs/job-id', execution_status={'state': 'READY'}
-        ),
-    )
-    client().get_job_async.return_value = quantum.QuantumJob(
+    canceled_job = quantum.QuantumJob(
         name='projects/proj/programs/prog/jobs/job-id', execution_status={'state': 'CANCELLED'}
     )
+    stream_future = duet.AwaitableFuture()
+    stream_future.try_set_result(canceled_job)
+    client().run_job_over_stream.return_value = stream_future
 
     engine = cg.Engine(project_id='proj')
     with pytest.raises(
         RuntimeError, match='Job projects/proj/programs/prog/jobs/job-id failed in state CANCELLED.'
     ):
-        engine.run(program=_CIRCUIT)
-
-
-@mock.patch('cirq_google.engine.engine_client.EngineClient', autospec=True)
-def test_run_circuit_timeout(client):
-    client().create_program_async.return_value = (
-        'prog',
-        quantum.QuantumProgram(name='projects/proj/programs/prog'),
-    )
-    client().create_job_async.return_value = (
-        'job-id',
-        quantum.QuantumJob(
-            name='projects/proj/programs/prog/jobs/job-id', execution_status={'state': 'READY'}
-        ),
-    )
-    client().get_job_async.return_value = quantum.QuantumJob(
-        name='projects/proj/programs/prog/jobs/job-id', execution_status={'state': 'RUNNING'}
-    )
-
-    engine = cg.Engine(project_id='project-id', timeout=1)
-    with pytest.raises(TimeoutError):
         engine.run(program=_CIRCUIT)
 
 
@@ -510,18 +472,15 @@ def test_run_sweep_params(client):
         assert results[i].params.param_dict == {'a': v}
         assert results[i].measurements == {'q': np.array([[0]], dtype='uint8')}
 
-    client().create_program_async.assert_called_once()
-    client().create_job_async.assert_called_once()
+    client().run_job_over_stream.assert_called_once()
 
     run_context = v2.run_context_pb2.RunContext()
-    client().create_job_async.call_args[1]['run_context'].Unpack(run_context)
+    client().run_job_over_stream.call_args[1]['run_context'].Unpack(run_context)
     sweeps = run_context.parameter_sweeps
     assert len(sweeps) == 2
     for i, v in enumerate([1.0, 2.0]):
         assert sweeps[i].repetitions == 1
         assert sweeps[i].sweep.sweep_function.sweeps[0].single_sweep.points.points == [v]
-    client().get_job_async.assert_called_once()
-    client().get_job_results_async.assert_called_once()
 
 
 @mock.patch('cirq_google.engine.engine_client.EngineClient', autospec=True)
@@ -567,16 +526,13 @@ def test_run_sweep_v2(client):
         assert results[i].repetitions == 1
         assert results[i].params.param_dict == {'a': v}
         assert results[i].measurements == {'q': np.array([[0]], dtype='uint8')}
-    client().create_program_async.assert_called_once()
-    client().create_job_async.assert_called_once()
+    client().run_job_over_stream.assert_called_once()
     run_context = v2.run_context_pb2.RunContext()
-    client().create_job_async.call_args[1]['run_context'].Unpack(run_context)
+    client().run_job_over_stream.call_args[1]['run_context'].Unpack(run_context)
     sweeps = run_context.parameter_sweeps
     assert len(sweeps) == 1
     assert sweeps[0].repetitions == 1
     assert sweeps[0].sweep.single_sweep.points.points == [1, 2]
-    client().get_job_async.assert_called_once()
-    client().get_job_results_async.assert_called_once()
 
 
 @mock.patch('cirq_google.engine.engine_client.EngineClient', autospec=True)
@@ -732,7 +688,7 @@ def test_bad_program_proto():
     engine = cg.Engine(
         project_id='project-id', proto_version=cg.engine.engine.ProtoVersion.UNDEFINED
     )
-    with pytest.raises(ValueError, match='invalid program proto version'):
+    with pytest.raises(ValueError, match='invalid (program|run context) proto version'):
         engine.run_sweep(program=_CIRCUIT)
     with pytest.raises(ValueError, match='invalid program proto version'):
         engine.create_program(_CIRCUIT)
@@ -817,7 +773,7 @@ def test_sampler(client):
         assert results[i].repetitions == 1
         assert results[i].params.param_dict == {'a': v}
         assert results[i].measurements == {'q': np.array([[0]], dtype='uint8')}
-    assert client().create_program_async.call_args[0][0] == 'proj'
+    assert client().run_job_over_stream.call_args[1]['project_id'] == 'proj'
 
     with cirq.testing.assert_deprecated('sampler', deadline='1.0'):
         _ = engine.sampler(processor_id='tmp')

--- a/cirq-google/cirq_google/engine/stream_manager.py
+++ b/cirq-google/cirq_google/engine/stream_manager.py
@@ -12,16 +12,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict
+from typing import AsyncIterator, Dict, Optional, Union
 import asyncio
+import duet
 
-from google.api_core.exceptions import GoogleAPICallError
+import google.api_core.exceptions as google_exceptions
 
 from cirq_google.cloud import quantum
+from cirq_google.engine.asyncio_executor import AsyncioExecutor
+
+Code = quantum.StreamError.Code
+
+
+RETRYABLE_GOOGLE_API_EXCEPTIONS = [
+    google_exceptions.InternalServerError,
+    google_exceptions.ServiceUnavailable,
+]
+
+
+class ProgramAlreadyExistsError(Exception):
+    def __init__(self, program_name: str):
+        # Call the base class constructor with the parameters it needs
+        super().__init__(f"'{program_name}' already exists")
+
+
+class StreamError(Exception):
+    pass
 
 
 class ResponseDemux:
-    """A event demultiplexer for QuantumRunStreamResponses, as part of the async reactor pattern.
+    """An event demultiplexer for QuantumRunStreamResponses, as part of the async reactor pattern.
 
     A caller can subscribe to the response matching a provided message ID. Only a single caller may
     subscribe to each ID.
@@ -32,7 +52,7 @@ class ResponseDemux:
     A caller can also publish an exception to all subscribers.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         # [message ID] : [subscriber future]
         self._subscribers: Dict[str, asyncio.Future] = {}
 
@@ -66,7 +86,7 @@ class ResponseDemux:
         if future and not future.done():
             future.set_result(response)
 
-    def publish_exception(self, exception: GoogleAPICallError) -> None:
+    def publish_exception(self, exception: BaseException) -> None:
         """Publishes an exception to all outstanding futures."""
         for future in self._subscribers.values():
             if not future.done():
@@ -75,5 +95,271 @@ class ResponseDemux:
 
 
 class StreamManager:
-    # TODO(verult) Implement
-    pass
+    """Manages communication with Quantum Engine via QuantumRunStream, a bi-directional stream RPC.
+
+    The main manager method is `submit()`, which sends the provided job to Quantum Engine through
+    the stream and returns a future to be completed when either the result is ready or the job has
+    failed. The submitted job can also be cancelled by calling `cancel()` on the future returned by
+    `submit()`.
+
+    A new stream is opened during the first `submit()` call, and it stays open. If the stream is
+    unused, users can close the stream and free management resources by calling `stop()`.
+
+    """
+
+    def __init__(self, grpc_client: quantum.QuantumEngineServiceAsyncClient):
+        self._grpc_client = grpc_client
+        # TODO(#5996) Make this local to the asyncio thread.
+        self._request_queue: Optional[asyncio.Queue] = None
+        # Used to determine whether the stream coroutine is actively running, and provides a way to
+        # cancel it.
+        self._manage_stream_loop_future: Optional[duet.AwaitableFuture[None]] = None
+        # TODO(#5996) consider making the scope of response futures local to the relevant tasks
+        # rather than all of StreamManager.
+        # Currently, this field is being written to from both duet and asyncio threads. While the
+        # ResponseDemux implementation does support this, it does not guarantee thread safety in its
+        # interface.
+        self._response_demux = ResponseDemux()
+        self._next_available_message_id = 0
+
+    def submit(
+        self, project_name: str, program: quantum.QuantumProgram, job: quantum.QuantumJob
+    ) -> duet.AwaitableFuture[Union[quantum.QuantumResult, quantum.QuantumJob]]:
+        """Submits a job over the stream and returns a future for the result.
+
+        If submit() is called for the first time since StreamManager instantiation or since the last
+        time stop() was called, it will create a new long-running stream.
+
+        The job can be cancelled by calling `cancel()` on the returned future.
+
+        Args:
+            project_name: The full project ID resource path associated with the job.
+            program: The Quantum Engine program representing the circuit to be executed. The program
+                name must be set.
+            job: The Quantum Engine job to be executed.
+
+        Returns:
+            A future for the job result, or the job if the job has failed.
+
+        Raises:
+            ProgramAlreadyExistsError: if the program already exists.
+            StreamError: if there is a non-retryable error while executing the job.
+            ValueError: if program name is not set.
+            concurrent.futures.CancelledError: if the stream is stopped while a job is in flight.
+            google.api_core.exceptions.GoogleAPICallError: if the stream breaks with a non-retryable
+                error.
+        """
+        if 'name' not in program:
+            raise ValueError('Program name must be set.')
+
+        if self._manage_stream_loop_future is None or self._manage_stream_loop_future.done():
+            self._manage_stream_loop_future = self._executor.submit(self._manage_stream)
+        return self._executor.submit(self._manage_execution, project_name, program, job)
+
+    def stop(self) -> None:
+        """Closes the open stream and resets all management resources."""
+        if (
+            self._manage_stream_loop_future is not None
+            and not self._manage_stream_loop_future.done()
+        ):
+            self._manage_stream_loop_future.cancel()
+        self._response_demux.publish_exception(asyncio.CancelledError())
+        self._reset()
+
+    def _reset(self):
+        """Resets the manager state."""
+        self._request_queue = None
+        self._manage_stream_loop_future = None
+        self._response_demux = ResponseDemux()
+
+    @property
+    def _executor(self) -> AsyncioExecutor:
+        # We must re-use a single Executor due to multi-threading issues in gRPC
+        # clients: https://github.com/grpc/grpc/issues/25364.
+        return AsyncioExecutor.instance()
+
+    async def _manage_stream(self) -> None:
+        """The stream coroutine, an asyncio coroutine to manage QuantumRunStream.
+
+        This coroutine reads responses from the stream and forwards them to the ResponseDemux, where
+        the corresponding execution coroutine `_manage_request()` is notified.
+
+        When the stream breaks, the stream is reopened, and all execution coroutines are notified.
+
+        There is at most a single instance of this coroutine running.
+        """
+        self._request_queue = asyncio.Queue()
+        while True:
+            try:
+                # The default gRPC client timeout is used.
+                response_iterable = await self._grpc_client.quantum_run_stream(
+                    _request_iterator(self._request_queue)
+                )
+                async for response in response_iterable:
+                    self._response_demux.publish(response)
+            except asyncio.CancelledError:
+                break
+            except BaseException as e:
+                # TODO(#5996) Close the request iterator to close the existing stream.
+                # Note: the message ID counter is not reset upon a new stream.
+                self._response_demux.publish_exception(e)  # Raise to all request tasks
+
+    async def _manage_execution(
+        self, project_name: str, program: quantum.QuantumProgram, job: quantum.QuantumJob
+    ) -> Union[quantum.QuantumResult, quantum.QuantumJob]:
+        """The execution coroutine, an asyncio coroutine to manage the lifecycle of a job execution.
+
+        This coroutine sends QuantumRunStream requests to the request iterator and receives
+        responses from the ResponseDemux.
+
+        It initially sends a CreateQuantumProgramAndJobRequest, and retries if there is a retryable
+        error by sending another request. The exact request type depends on the error.
+
+        There is one execution coroutine per running job submission.
+        """
+        # Construct requests ahead of time to be reused for retries.
+        create_program_and_job_request = quantum.QuantumRunStreamRequest(
+            parent=project_name,
+            create_quantum_program_and_job=quantum.CreateQuantumProgramAndJobRequest(
+                parent=project_name, quantum_program=program, quantum_job=job
+            ),
+        )
+
+        while self._request_queue is None:
+            # Wait for the stream coroutine to start.
+            # Ignoring coverage since this is rarely triggered.
+            # TODO(#5996) Consider awaiting for the queue to become available, once it is changed
+            # to be local to the asyncio thread.
+            await asyncio.sleep(1)  # coverage: ignore
+
+        current_request = create_program_and_job_request
+        while True:
+            try:
+                current_request.message_id = self._generate_message_id()
+                response_future = self._response_demux.subscribe(current_request.message_id)
+                await self._request_queue.put(current_request)
+                response = await response_future
+
+            # Broken stream
+            except google_exceptions.GoogleAPICallError as e:
+                if not _is_retryable_error(e):
+                    raise e
+
+                # Retry
+                current_request = _to_get_result_request(create_program_and_job_request)
+                continue
+                # TODO(#5996) add exponential backoff
+
+            # Either when this request is canceled or the _manage_stream() loop is canceled.
+            except asyncio.CancelledError:
+                # TODO(#5996) Consider moving the request future cancellation logic into a future
+                # done callback, so that the the cancellation caller can wait for it to complete.
+                # TODO(#5996) Check the condition that response_future is not done before
+                # cancelling, once request cancellation is moved to a callback.
+                if response_future is not None:
+                    response_future.cancel()
+                    await self._cancel(job.name)
+                raise
+
+            # Response handling
+            if 'result' in response:
+                return response.result
+            elif 'job' in response:
+                return response.job
+            elif 'error' in response:
+                current_request = _get_retry_request_or_raise(
+                    response.error,
+                    current_request,
+                    create_program_and_job_request,
+                    _to_create_job_request(create_program_and_job_request),
+                )
+                continue
+            else:
+                # coverage: ignore
+                raise ValueError(
+                    'The Quantum Engine response type is not recognized by this client. '
+                    'This may be due to an outdated version of cirq-google'
+                )
+
+    async def _cancel(self, job_name: str) -> None:
+        await self._grpc_client.cancel_quantum_job(quantum.CancelQuantumJobRequest(name=job_name))
+
+    def _generate_message_id(self) -> str:
+        message_id = str(self._next_available_message_id)
+        self._next_available_message_id += 1
+        return message_id
+
+
+def _get_retry_request_or_raise(
+    error: quantum.StreamError,
+    current_request,
+    create_program_and_job_request,
+    create_job_request: quantum.QuantumRunStreamRequest,
+):
+    """Decide whether the given stream error is retryable.
+
+    If it is, returns the next stream request to send upon retry. Otherwise, raises an error.
+    """
+    if error.code == Code.PROGRAM_DOES_NOT_EXIST:
+        if 'create_quantum_job' in current_request:
+            return create_program_and_job_request
+    elif error.code == Code.PROGRAM_ALREADY_EXISTS:
+        if 'create_quantum_program_and_job' in current_request:
+            raise ProgramAlreadyExistsError(
+                current_request.create_quantum_program_and_job.quantum_program.name
+            )
+    elif error.code == Code.JOB_DOES_NOT_EXIST:
+        if 'get_quantum_result' in current_request:
+            return create_job_request
+
+    # Code.JOB_ALREADY_EXISTS should never happen.
+    # The first stream request is always a CreateQuantumProgramAndJobRequest, which never fails
+    # with this error because jobs are scoped within a program.
+    # CreateQuantumJobRequests would fail with a PROGRAM_ALREADY_EXISTS if the job already
+    # exists because program and job creation happen atomically for a
+    # CreateQuantumProgramAndJobRequest.
+
+    raise StreamError(error.message)
+
+
+def _is_retryable_error(e: google_exceptions.GoogleAPICallError) -> bool:
+    return any(isinstance(e, exception_type) for exception_type in RETRYABLE_GOOGLE_API_EXCEPTIONS)
+
+
+# TODO(#5996) Add stop signal to the request iterator.
+async def _request_iterator(
+    request_queue: asyncio.Queue,
+) -> AsyncIterator[quantum.QuantumRunStreamRequest]:
+    """The request iterator for Quantum Engine client RPC quantum_run_stream().
+
+    Every call to this method generates a new iterator.
+    """
+    while True:
+        yield await request_queue.get()
+
+
+def _to_create_job_request(
+    create_program_and_job_request: quantum.QuantumRunStreamRequest,
+) -> quantum.QuantumRunStreamRequest:
+    """Converted the QuantumRunStreamRequest from a CreateQuantumProgramAndJobRequest to a
+    CreateQuantumJobRequest.
+    """
+    program = create_program_and_job_request.create_quantum_program_and_job.quantum_program
+    job = create_program_and_job_request.create_quantum_program_and_job.quantum_job
+    return quantum.QuantumRunStreamRequest(
+        parent=create_program_and_job_request.parent,
+        create_quantum_job=quantum.CreateQuantumJobRequest(parent=program.name, quantum_job=job),
+    )
+
+
+def _to_get_result_request(
+    create_program_and_job_request: quantum.QuantumRunStreamRequest,
+) -> quantum.QuantumRunStreamRequest:
+    """Converted the QuantumRunStreamRequest from a CreateQuantumProgramAndJobRequest to a
+    GetQuantumResultRequest.
+    """
+    job = create_program_and_job_request.create_quantum_program_and_job.quantum_job
+    return quantum.QuantumRunStreamRequest(
+        parent=create_program_and_job_request.parent,
+        get_quantum_result=quantum.GetQuantumResultRequest(parent=job.name),
+    )

--- a/cirq-google/cirq_google/engine/stream_manager_test.py
+++ b/cirq-google/cirq_google/engine/stream_manager_test.py
@@ -12,13 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import AsyncIterable, AsyncIterator, Awaitable, List, Union
 import asyncio
+import concurrent
+from unittest import mock
+
+import duet
 import pytest
 import google.api_core.exceptions as google_exceptions
 
-from cirq_google.engine.stream_manager import ResponseDemux
+from cirq_google.engine.stream_manager import (
+    _get_retry_request_or_raise,
+    ProgramAlreadyExistsError,
+    ResponseDemux,
+    StreamError,
+    StreamManager,
+)
 from cirq_google.cloud import quantum
 
+
+Code = quantum.StreamError.Code
+
+
+# ResponseDemux test suite constants
 RESPONSE0 = quantum.QuantumRunStreamResponse(
     message_id='0', result=quantum.QuantumResult(parent='projects/proj/programs/prog/jobs/job0')
 )
@@ -28,6 +44,67 @@ RESPONSE1 = quantum.QuantumRunStreamResponse(
 RESPONSE1_WITH_DIFFERENT_RESULT = quantum.QuantumRunStreamResponse(
     message_id='1', result=quantum.QuantumResult(parent='projects/proj/programs/prog/jobs/job2')
 )
+
+
+# StreamManager test suite constants
+REQUEST_PROJECT_NAME = 'projects/proj'
+REQUEST_PROGRAM = quantum.QuantumProgram(name='projects/proj/programs/prog')
+REQUEST_JOB = quantum.QuantumJob(name='projects/proj/programs/prog/jobs/job0')
+
+
+def setup_fake_quantum_run_stream_client(client_constructor, responses_and_exceptions):
+    grpc_client = FakeQuantumRunStream(responses_and_exceptions)
+    client_constructor.return_value = grpc_client
+    return grpc_client
+
+
+class FakeQuantumRunStream:
+    """A fake Quantum Engine client which supports QuantumRunStream and CancelQuantumJob."""
+
+    def __init__(
+        self, responses_and_exceptions: List[Union[quantum.QuantumRunStreamResponse, BaseException]]
+    ):
+        self.stream_requests: List[quantum.QuantumRunStreamRequest] = []
+        self.cancel_requests: List[quantum.CancelQuantumJobRequest] = []
+        self.responses_and_exceptions = responses_and_exceptions
+
+    async def quantum_run_stream(
+        self, requests: AsyncIterator[quantum.QuantumRunStreamRequest], **kwargs
+    ) -> Awaitable[AsyncIterable[quantum.QuantumRunStreamResponse]]:
+        """Fakes the QuantumRunStream RPC.
+
+        Expects the number of requests to be the same as len(self.responses_and_exceptions).
+
+        For every request, a response or exception is popped from `self.responses_and_exceptions`.
+        Before the next request:
+            * If it is a response, it is sent back through the stream.
+            * If it is an exception, the exception is raised.
+
+        This fake does not support out-of-order responses.
+
+        No responses are ever made if `self.responses_and_exceptions` is empty.
+        """
+
+        async def run_async_iterator():
+            async for request in requests:
+                self.stream_requests.append(request)
+
+                if not self.responses_and_exceptions:
+                    while True:
+                        await asyncio.sleep(1)
+
+                response_or_exception = self.responses_and_exceptions.pop(0)
+                if isinstance(response_or_exception, BaseException):
+                    raise response_or_exception
+                response_or_exception.message_id = request.message_id
+                yield response_or_exception
+
+        await asyncio.sleep(0)
+        return run_async_iterator()
+
+    async def cancel_quantum_job(self, request: quantum.CancelQuantumJobRequest) -> None:
+        self.cancel_requests.append(request)
+        await asyncio.sleep(0)
 
 
 class TestResponseDemux:
@@ -125,3 +202,475 @@ class TestResponseDemux:
 
         assert actual_response0 == RESPONSE0
         assert actual_response1 == RESPONSE1
+
+
+class TestStreamManager:
+    @mock.patch.object(quantum, 'QuantumEngineServiceAsyncClient', autospec=True)
+    def test_submit_expects_result_response(self, client_constructor):
+        async def test():
+            async with duet.timeout_scope(5):
+                # Arrange
+                expected_result = quantum.QuantumResult(
+                    parent='projects/proj/programs/prog/jobs/job0'
+                )
+                mock_responses = [quantum.QuantumRunStreamResponse(result=expected_result)]
+                fake_client = setup_fake_quantum_run_stream_client(
+                    client_constructor, responses_and_exceptions=mock_responses
+                )
+                manager = StreamManager(fake_client)
+
+                # Act
+                actual_result = await manager.submit(
+                    REQUEST_PROJECT_NAME, REQUEST_PROGRAM, REQUEST_JOB
+                )
+                manager.stop()
+
+                # Assert
+                assert actual_result == expected_result
+                assert len(fake_client.stream_requests) == 1
+                # assert that the first request is a CreateQuantumProgramAndJobRequest.
+                assert 'create_quantum_program_and_job' in fake_client.stream_requests[0]
+
+        duet.run(test)
+
+    @mock.patch.object(quantum, 'QuantumEngineServiceAsyncClient', autospec=True)
+    def test_submit_program_without_name_raises(self, client_constructor):
+        async def test():
+            async with duet.timeout_scope(5):
+                # Arrange
+                expected_result = quantum.QuantumResult(
+                    parent='projects/proj/programs/prog/jobs/job0'
+                )
+                mock_responses = [quantum.QuantumRunStreamResponse(result=expected_result)]
+                fake_client = setup_fake_quantum_run_stream_client(
+                    client_constructor, responses_and_exceptions=mock_responses
+                )
+                manager = StreamManager(fake_client)
+
+                with pytest.raises(ValueError, match='Program name must be set'):
+                    await manager.submit(
+                        REQUEST_PROJECT_NAME, quantum.QuantumProgram(), REQUEST_JOB
+                    )
+                manager.stop()
+
+        duet.run(test)
+
+    @mock.patch.object(quantum, 'QuantumEngineServiceAsyncClient', autospec=True)
+    def test_submit_cancel_future_expects_engine_cancellation_rpc_call(self, client_constructor):
+        async def test():
+            async with duet.timeout_scope(5):
+                fake_client = setup_fake_quantum_run_stream_client(
+                    client_constructor, responses_and_exceptions=[]
+                )
+                manager = StreamManager(fake_client)
+
+                result_future = manager.submit(REQUEST_PROJECT_NAME, REQUEST_PROGRAM, REQUEST_JOB)
+                result_future.cancel()
+                await duet.sleep(1)  # Let cancellation complete asynchronously
+                manager.stop()
+
+                assert len(fake_client.cancel_requests) == 1
+                assert fake_client.cancel_requests[0] == quantum.CancelQuantumJobRequest(
+                    name='projects/proj/programs/prog/jobs/job0'
+                )
+
+        duet.run(test)
+
+    @mock.patch.object(quantum, 'QuantumEngineServiceAsyncClient', autospec=True)
+    def test_submit_stream_broken_twice_expects_retry_with_get_quantum_result_twice(
+        self, client_constructor
+    ):
+        async def test():
+            async with duet.timeout_scope(5):
+                expected_result = quantum.QuantumResult(
+                    parent='projects/proj/programs/prog/jobs/job0'
+                )
+                mock_responses_and_exceptions = [
+                    google_exceptions.ServiceUnavailable('unavailable'),
+                    google_exceptions.ServiceUnavailable('unavailable'),
+                    quantum.QuantumRunStreamResponse(result=expected_result),
+                ]
+                fake_client = setup_fake_quantum_run_stream_client(
+                    client_constructor, responses_and_exceptions=mock_responses_and_exceptions
+                )
+                manager = StreamManager(fake_client)
+
+                actual_result = await manager.submit(
+                    REQUEST_PROJECT_NAME, REQUEST_PROGRAM, REQUEST_JOB
+                )
+                manager.stop()
+
+                assert actual_result == expected_result
+                assert len(fake_client.stream_requests) == 3
+                assert 'create_quantum_program_and_job' in fake_client.stream_requests[0]
+                assert 'get_quantum_result' in fake_client.stream_requests[1]
+                assert 'get_quantum_result' in fake_client.stream_requests[2]
+
+        duet.run(test)
+
+    @pytest.mark.parametrize(
+        'error',
+        [
+            google_exceptions.InternalServerError('server error'),
+            google_exceptions.ServiceUnavailable('unavailable'),
+        ],
+    )
+    @mock.patch.object(quantum, 'QuantumEngineServiceAsyncClient', autospec=True)
+    def test_submit_with_retryable_stream_breakage_expects_get_result_request(
+        self, client_constructor, error
+    ):
+        async def test():
+            async with duet.timeout_scope(5):
+                mock_responses = [
+                    error,
+                    quantum.QuantumRunStreamResponse(
+                        result=quantum.QuantumResult(parent='projects/proj/programs/prog/jobs/job0')
+                    ),
+                ]
+                fake_client = setup_fake_quantum_run_stream_client(
+                    client_constructor, responses_and_exceptions=mock_responses
+                )
+                manager = StreamManager(fake_client)
+
+                await manager.submit(REQUEST_PROJECT_NAME, REQUEST_PROGRAM, REQUEST_JOB)
+                manager.stop()
+
+                assert len(fake_client.stream_requests) == 2
+                assert 'create_quantum_program_and_job' in fake_client.stream_requests[0]
+                assert 'get_quantum_result' in fake_client.stream_requests[1]
+
+        duet.run(test)
+
+    @pytest.mark.parametrize(
+        'error',
+        [
+            # Including errors which are likely to occur.
+            google_exceptions.DeadlineExceeded('deadline exceeded'),
+            google_exceptions.FailedPrecondition('failed precondition'),
+            google_exceptions.Forbidden('forbidden'),
+            google_exceptions.InvalidArgument('invalid argument'),
+            google_exceptions.ResourceExhausted('resource exhausted'),
+            google_exceptions.TooManyRequests('too many requests'),
+            google_exceptions.Unauthenticated('unauthenticated'),
+            google_exceptions.Unauthorized('unauthorized'),
+            google_exceptions.Unknown('unknown'),
+        ],
+    )
+    @mock.patch.object(quantum, 'QuantumEngineServiceAsyncClient', autospec=True)
+    def test_submit_with_non_retryable_stream_breakage_raises_error(
+        self, client_constructor, error
+    ):
+        async def test():
+            async with duet.timeout_scope(5):
+                mock_responses = [
+                    error,
+                    quantum.QuantumRunStreamResponse(
+                        result=quantum.QuantumResult(parent='projects/proj/programs/prog/jobs/job0')
+                    ),
+                ]
+                fake_client = setup_fake_quantum_run_stream_client(
+                    client_constructor, responses_and_exceptions=mock_responses
+                )
+                manager = StreamManager(fake_client)
+
+                with pytest.raises(type(error)):
+                    await manager.submit(REQUEST_PROJECT_NAME, REQUEST_PROGRAM, REQUEST_JOB)
+                manager.stop()
+
+                assert len(fake_client.stream_requests) == 1
+                assert 'create_quantum_program_and_job' in fake_client.stream_requests[0]
+
+        duet.run(test)
+
+    @mock.patch.object(quantum, 'QuantumEngineServiceAsyncClient', autospec=True)
+    def test_submit_expects_job_response(self, client_constructor):
+        async def test():
+            async with duet.timeout_scope(5):
+                expected_job = quantum.QuantumJob(name='projects/proj/programs/prog/jobs/job0')
+                mock_responses = [quantum.QuantumRunStreamResponse(job=expected_job)]
+                fake_client = setup_fake_quantum_run_stream_client(
+                    client_constructor, responses_and_exceptions=mock_responses
+                )
+                manager = StreamManager(fake_client)
+
+                actual_job = await manager.submit(
+                    REQUEST_PROJECT_NAME, REQUEST_PROGRAM, REQUEST_JOB
+                )
+                manager.stop()
+
+                assert actual_job == expected_job
+                assert len(fake_client.stream_requests) == 1
+                # assert that the first request is a CreateQuantumProgramAndJobRequest.
+                assert 'create_quantum_program_and_job' in fake_client.stream_requests[0]
+
+        duet.run(test)
+
+    @mock.patch.object(quantum, 'QuantumEngineServiceAsyncClient', autospec=True)
+    def test_submit_job_does_not_exist_expects_create_quantum_job_request(self, client_constructor):
+        async def test():
+            async with duet.timeout_scope(5):
+                expected_result = quantum.QuantumResult(
+                    parent='projects/proj/programs/prog/jobs/job0'
+                )
+                mock_responses_and_exceptions = [
+                    google_exceptions.ServiceUnavailable('unavailable'),
+                    quantum.QuantumRunStreamResponse(
+                        error=quantum.StreamError(code=quantum.StreamError.Code.JOB_DOES_NOT_EXIST)
+                    ),
+                    quantum.QuantumRunStreamResponse(result=expected_result),
+                ]
+                fake_client = setup_fake_quantum_run_stream_client(
+                    client_constructor, responses_and_exceptions=mock_responses_and_exceptions
+                )
+                manager = StreamManager(fake_client)
+
+                actual_result = await manager.submit(
+                    REQUEST_PROJECT_NAME, REQUEST_PROGRAM, REQUEST_JOB
+                )
+                manager.stop()
+
+                assert actual_result == expected_result
+                assert len(fake_client.stream_requests) == 3
+                assert 'create_quantum_program_and_job' in fake_client.stream_requests[0]
+                assert 'get_quantum_result' in fake_client.stream_requests[1]
+                assert 'create_quantum_job' in fake_client.stream_requests[2]
+
+        duet.run(test)
+
+    @mock.patch.object(quantum, 'QuantumEngineServiceAsyncClient', autospec=True)
+    def test_submit_program_does_not_exist_expects_create_quantum_program_and_job_request(
+        self, client_constructor
+    ):
+        async def test():
+            async with duet.timeout_scope(5):
+                expected_result = quantum.QuantumResult(
+                    parent='projects/proj/programs/prog/jobs/job0'
+                )
+                mock_responses_and_exceptions = [
+                    google_exceptions.ServiceUnavailable('unavailable'),
+                    quantum.QuantumRunStreamResponse(
+                        error=quantum.StreamError(code=quantum.StreamError.Code.JOB_DOES_NOT_EXIST)
+                    ),
+                    quantum.QuantumRunStreamResponse(
+                        error=quantum.StreamError(
+                            code=quantum.StreamError.Code.PROGRAM_DOES_NOT_EXIST
+                        )
+                    ),
+                    quantum.QuantumRunStreamResponse(result=expected_result),
+                ]
+                fake_client = setup_fake_quantum_run_stream_client(
+                    client_constructor, responses_and_exceptions=mock_responses_and_exceptions
+                )
+                manager = StreamManager(fake_client)
+
+                actual_result = await manager.submit(
+                    REQUEST_PROJECT_NAME, REQUEST_PROGRAM, REQUEST_JOB
+                )
+                manager.stop()
+
+                assert actual_result == expected_result
+                assert len(fake_client.stream_requests) == 4
+                assert 'create_quantum_program_and_job' in fake_client.stream_requests[0]
+                assert 'get_quantum_result' in fake_client.stream_requests[1]
+                assert 'create_quantum_job' in fake_client.stream_requests[2]
+                assert 'create_quantum_program_and_job' in fake_client.stream_requests[3]
+
+        duet.run(test)
+
+    @mock.patch.object(quantum, 'QuantumEngineServiceAsyncClient', autospec=True)
+    def test_submit_program_already_exists_expects_program_already_exists_error(
+        self, client_constructor
+    ):
+        async def test():
+            async with duet.timeout_scope(5):
+                mock_responses_and_exceptions = [
+                    quantum.QuantumRunStreamResponse(
+                        error=quantum.StreamError(
+                            code=quantum.StreamError.Code.PROGRAM_ALREADY_EXISTS
+                        )
+                    )
+                ]
+                fake_client = setup_fake_quantum_run_stream_client(
+                    client_constructor, responses_and_exceptions=mock_responses_and_exceptions
+                )
+                manager = StreamManager(fake_client)
+
+                with pytest.raises(ProgramAlreadyExistsError):
+                    await manager.submit(REQUEST_PROJECT_NAME, REQUEST_PROGRAM, REQUEST_JOB)
+                manager.stop()
+
+        duet.run(test)
+
+    @mock.patch.object(quantum, 'QuantumEngineServiceAsyncClient', autospec=True)
+    def test_submit_twice_in_parallel_expect_result_responses(self, client_constructor):
+        async def test():
+            async with duet.timeout_scope(5):
+                request_job1 = quantum.QuantumJob(name='projects/proj/programs/prog/jobs/job1')
+                expected_result0 = quantum.QuantumResult(
+                    parent='projects/proj/programs/prog/jobs/job0'
+                )
+                expected_result1 = quantum.QuantumResult(
+                    parent='projects/proj/programs/prog/jobs/job1'
+                )
+                mock_responses = [
+                    quantum.QuantumRunStreamResponse(result=expected_result0),
+                    quantum.QuantumRunStreamResponse(result=expected_result1),
+                ]
+                fake_client = setup_fake_quantum_run_stream_client(
+                    client_constructor, responses_and_exceptions=mock_responses
+                )
+                manager = StreamManager(fake_client)
+
+                actual_result0_future = manager.submit(
+                    REQUEST_PROJECT_NAME, REQUEST_PROGRAM, REQUEST_JOB
+                )
+                actual_result1_future = manager.submit(
+                    REQUEST_PROJECT_NAME, REQUEST_PROGRAM, request_job1
+                )
+                actual_result1 = await actual_result1_future
+                actual_result0 = await actual_result0_future
+                manager.stop()
+
+                assert actual_result0 == expected_result0
+                assert actual_result1 == expected_result1
+                assert len(fake_client.stream_requests) == 2
+                assert 'create_quantum_program_and_job' in fake_client.stream_requests[0]
+                assert 'create_quantum_program_and_job' in fake_client.stream_requests[1]
+
+        duet.run(test)
+
+    # TODO(#5996) Update fake client implementation to support this test case.
+    # @mock.patch.object(quantum, 'QuantumEngineServiceAsyncClient', autospec=True)
+    # def test_submit_twice_and_break_stream_expect_result_responses(self, client_constructor):
+    #     async def test():
+    #         async with duet.timeout_scope(5):
+    #             request_job1 = quantum.QuantumJob(name='projects/proj/programs/prog/jobs/job1')
+    #             expected_result0 = quantum.QuantumResult(
+    #                 parent='projects/proj/programs/prog/jobs/job0'
+    #             )
+    #             expected_result1 = quantum.QuantumResult(
+    #                 parent='projects/proj/programs/prog/jobs/job1'
+    #             )
+    #             # TODO the current fake client doesn't have the response timing flexibility
+    #             # required by this test.
+    #             # Ideally, the client raises ServiceUnavailable after both initial requests are
+    #             # sent.
+    #             mock_responses = [
+    #                 google_exceptions.ServiceUnavailable('unavailable'),
+    #                 google_exceptions.ServiceUnavailable('unavailable'),
+    #                 quantum.QuantumRunStreamResponse(result=expected_result0),
+    #                 quantum.QuantumRunStreamResponse(result=expected_result1),
+    #             ]
+    #             fake_client = setup_fake_quantum_run_stream_client(
+    #                 client_constructor, responses_and_exceptions=mock_responses
+    #             )
+    #             manager = StreamManager(fake_client)
+
+    #             actual_result0_future = manager.submit(
+    #                 REQUEST_PROJECT_NAME, REQUEST_PROGRAM, REQUEST_JOB
+    #             )
+    #             actual_result1_future = manager.submit(
+    #                 REQUEST_PROJECT_NAME, REQUEST_PROGRAM, request_job1
+    #             )
+    #             actual_result1 = await actual_result1_future
+    #             actual_result0 = await actual_result0_future
+    #             manager.stop()
+
+    #             assert actual_result0 == expected_result0
+    #             assert actual_result1 == expected_result1
+    #             assert len(fake_client.stream_requests) == 2
+    #             assert 'create_quantum_program_and_job' in fake_client.stream_requests[0]
+    #             assert 'create_quantum_program_and_job' in fake_client.stream_requests[1]
+
+    #     duet.run(test)
+
+    @mock.patch.object(quantum, 'QuantumEngineServiceAsyncClient', autospec=True)
+    def test_stop_cancels_existing_sends(self, client_constructor):
+        async def test():
+            async with duet.timeout_scope(5):
+                fake_client = setup_fake_quantum_run_stream_client(
+                    client_constructor, responses_and_exceptions=[]
+                )
+                manager = StreamManager(fake_client)
+
+                actual_result_future = manager.submit(
+                    REQUEST_PROJECT_NAME, REQUEST_PROGRAM, REQUEST_JOB
+                )
+                # Wait for the manager to submit a request. If request submission runs after stop(),
+                # it will start the manager again and the test will block waiting for a response.
+                await duet.sleep(1)
+                manager.stop()
+
+                with pytest.raises(concurrent.futures.CancelledError):
+                    await actual_result_future
+
+        duet.run(test)
+
+    @mock.patch.object(quantum, 'QuantumEngineServiceAsyncClient', autospec=True)
+    def test_stop_then_send_expects_result_response(self, client_constructor):
+        """New requests should work after stopping the manager."""
+
+        async def test():
+            async with duet.timeout_scope(5):
+                expected_result = quantum.QuantumResult(
+                    parent='projects/proj/programs/prog/jobs/job0'
+                )
+                mock_responses = [quantum.QuantumRunStreamResponse(result=expected_result)]
+                fake_client = setup_fake_quantum_run_stream_client(
+                    client_constructor, responses_and_exceptions=mock_responses
+                )
+                manager = StreamManager(fake_client)
+
+                manager.stop()
+                actual_result = await manager.submit(
+                    REQUEST_PROJECT_NAME, REQUEST_PROGRAM, REQUEST_JOB
+                )
+                manager.stop()
+
+                assert actual_result == expected_result
+                assert len(fake_client.stream_requests) == 1
+                # assert that the first request is a CreateQuantumProgramAndJobRequest.
+                assert 'create_quantum_program_and_job' in fake_client.stream_requests[0]
+
+        duet.run(test)
+
+    @pytest.mark.parametrize(
+        'error_code, current_request_type',
+        [
+            (Code.PROGRAM_DOES_NOT_EXIST, 'create_quantum_program_and_job'),
+            (Code.PROGRAM_DOES_NOT_EXIST, 'get_quantum_result'),
+            (Code.PROGRAM_ALREADY_EXISTS, 'create_quantum_job'),
+            (Code.PROGRAM_ALREADY_EXISTS, 'get_quantum_result'),
+            (Code.JOB_DOES_NOT_EXIST, 'create_quantum_program_and_job'),
+            (Code.JOB_DOES_NOT_EXIST, 'create_quantum_job'),
+        ],
+    )
+    def test_get_retry_request_or_raise_expects_stream_error(
+        self, error_code, current_request_type
+    ):
+        # This tests a private function, but it's much easier to exhaustively test this function
+        # than to get the stream manager to issue specific requests required for each test case.
+
+        create_quantum_program_and_job_request = quantum.QuantumRunStreamRequest(
+            create_quantum_program_and_job=quantum.CreateQuantumProgramAndJobRequest()
+        )
+        create_quantum_job_request = quantum.QuantumRunStreamRequest(
+            create_quantum_job=quantum.CreateQuantumJobRequest()
+        )
+        get_quantum_result_request = quantum.QuantumRunStreamRequest(
+            get_quantum_result=quantum.GetQuantumResultRequest()
+        )
+        if current_request_type == 'create_quantum_program_and_job':
+            current_request = create_quantum_program_and_job_request
+        elif current_request_type == 'create_quantum_job':
+            current_request = create_quantum_job_request
+        elif current_request_type == 'get_quantum_result':
+            current_request = get_quantum_result_request
+
+        with pytest.raises(StreamError):
+            _get_retry_request_or_raise(
+                quantum.StreamError(code=error_code),
+                current_request,
+                create_quantum_program_and_job_request,
+                create_quantum_job_request,
+            )

--- a/cirq-ionq/cirq_ionq/__init__.py
+++ b/cirq-ionq/cirq_ionq/__init__.py
@@ -18,7 +18,7 @@ from cirq_ionq.calibration import Calibration
 
 from cirq_ionq.ionq_devices import IonQAPIDevice, decompose_to_device
 
-from cirq_ionq.ionq_gateset import IonQTargetGateset
+from cirq_ionq.ionq_gateset import IonQTargetGateset, decompose_all_to_all_connect_ccz_gate
 
 from cirq_ionq.ionq_exceptions import (
     IonQException,

--- a/cirq-ionq/cirq_ionq/ionq_gateset.py
+++ b/cirq-ionq/cirq_ionq/ionq_gateset.py
@@ -16,6 +16,7 @@
 from typing import Any
 from typing import Dict
 from typing import List
+from typing import Tuple
 
 import cirq
 
@@ -78,12 +79,21 @@ class IonQTargetGateset(cirq.TwoQubitCompilationTargetGateset):
             temp, k=1, rewriter=lambda op: self._decompose_single_qubit_operation(op, -1)
         ).all_operations()
 
+    def _decompose_multi_qubit_operation(self, op: cirq.Operation, _) -> cirq.OP_TREE:
+        if isinstance(op.gate, cirq.CCZPowGate):
+            return decompose_all_to_all_connect_ccz_gate(op.gate, op.qubits)
+        return NotImplemented
+
     @property
     def preprocess_transformers(self) -> List['cirq.TRANSFORMER']:
-        """List of transformers which should be run before decomposing individual operations."""
+        """List of transformers which should be run before decomposing individual operations.
+
+        Decompose to three qubit gates because three qubit gates have different decomposition
+        for all-to-all connectivity between qubits.
+        """
         return [
             cirq.create_transformer_with_kwargs(
-                cirq.expand_composite, no_decomp=lambda op: cirq.num_qubits(op) <= self.num_qubits
+                cirq.expand_composite, no_decomp=lambda op: cirq.num_qubits(op) <= 3
             )
         ]
 
@@ -104,3 +114,53 @@ class IonQTargetGateset(cirq.TwoQubitCompilationTargetGateset):
     @classmethod
     def _from_json_dict_(cls, atol, **kwargs):
         return cls(atol=atol)
+
+
+def decompose_all_to_all_connect_ccz_gate(
+    ccz_gate: 'cirq.CCZPowGate', qubits: Tuple['cirq.Qid', ...]
+) -> 'cirq.OP_TREE':
+    """Decomposition of all-to-all connected qubits are different from line qubits or grid qubits.
+
+    For example, for qubits in the same ion trap, the decomposition of CCZ gate will be:
+
+    0: ──────────────@──────────────────@───@───p──────@───
+                     │                  │   │          │
+    1: ───@──────────┼───────@───p──────┼───X───p^-1───X───
+          │          │       │          │
+    2: ───X───p^-1───X───p───X───p^-1───X───p──────────────
+
+    where p = T**ccz_gate._exponent
+    """
+    if len(qubits) != 3:
+        raise ValueError(f'Expect 3 qubits for CCZ gate, got {len(qubits)} qubits.')
+
+    a, b, c = qubits
+
+    p = cirq.T**ccz_gate._exponent
+    global_phase = 1j ** (2 * ccz_gate.global_shift * ccz_gate._exponent)
+    global_phase = (
+        complex(global_phase)
+        if cirq.is_parameterized(global_phase) and global_phase.is_complex  # type: ignore
+        else global_phase
+    )
+    global_phase_operation = (
+        [cirq.global_phase_operation(global_phase)]
+        if cirq.is_parameterized(global_phase) or abs(global_phase - 1.0) > 0
+        else []
+    )
+
+    return global_phase_operation + [
+        cirq.CNOT(b, c),
+        p(c) ** -1,
+        cirq.CNOT(a, c),
+        p(c),
+        cirq.CNOT(b, c),
+        p(c) ** -1,
+        cirq.CNOT(a, c),
+        p(b),
+        p(c),
+        cirq.CNOT(a, b),
+        p(a),
+        p(b) ** -1,
+        cirq.CNOT(a, b),
+    ]


### PR DESCRIPTION
Looking for approval on the general approach first before updating `run_batch()` and `run_calibration()` and adding tests.

* Connects the user interface of engine circuit execution with the `StreamManager` introduced in https://github.com/quantumlib/Cirq/pull/6199.
* `QuantumRunStream` supports `CreateQuantumProgramAndJob` requests, so the implementation here bypasses `EngineProgram` altogether, which will continue to use unary RPCs. This also aligns with our eventual goal of removing programs as a resource.
* `ProcessorSampler`, the recommended interface to run circuits on QuantumEngine, uses `Engine.run_sweep()` under the hood.

@dstrain115